### PR TITLE
added "source" to the command in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git clone https://github.com/AbsurdNerd/SimplifyReport_Backend
 - Create virtual environment-
 ```
 python -m venv env
-env\Scripts\activate
+source env\Scripts\activate
 ```
 - Install dependencies using-
 ```


### PR DESCRIPTION
The previous command was "env\Scripts\activate", but we need to use "source env\Scripts\activate" in Linux/bash terminal to make it work.